### PR TITLE
update to new event format

### DIFF
--- a/documentacion/webhooks-y-callbacks.mdx
+++ b/documentacion/webhooks-y-callbacks.mdx
@@ -147,6 +147,9 @@ const validUser(email) {
 Si realizaste un cambio de número de documento, nosotros realizaremos una validación asíncrona de los datos de la persona. Los resultados de esa valdación serán enviados a través de webhook
 
 `UPDATE_DOCUMENT_NUMBER`: Luego de una validación de datos, se recibirá un evento con este nombre en donde habrá un mensaje de confirmación, o un mensaje de error ya que hubo discrepancia en los datos del usuario.
+- `document_number_sucessfully_updated`: El proceso de validación de datos finalizo con éxito y el número de document se actualizo correctamente.
+
+- `document_number_failed_to_update`: Hubo un error en el proceso de validación de datos, por ejemplo: "Account does not have any personal info", "Account not found",  "There is incompatible personal info between the account and metamap".
 
 
 Ejemplo de una request:

--- a/documentacion/webhooks-y-callbacks.mdx
+++ b/documentacion/webhooks-y-callbacks.mdx
@@ -153,9 +153,13 @@ Ejemplo de una request:
 
 ```json
 {
-  "eventName": "UPDATE_DOCUMENT_NUMBER",
-  "message": "There is incompatible personal info between the account and metamap",
-  "timeStamp": "2022-10-26T22:36:41.658Z",
-  "signature": "ed40d34ab7a587cf1a16338a16cc7765ae4420936677482bb33f5f738e4f7189" // hash
+"eventName": "document_number_sucessfully_updated", // O "document_number_failed_to_update" si falló,
+"orderId": "UPDATE_DOCUMENT_NUMBER",
+"timeStamp": "2022-10-26T22:36:41.658Z",
+"data": {
+"email": {{email}},
+"message": {{Mensaje de error o completado}}
+},
+"signature": "ed40d34ab7a587cf1a16338a16cc7765ae4420936677482bb33f5f738e4f7189" // hash
 }
 ```

--- a/english/documentation/webhooks-and-callbacks.mdx
+++ b/english/documentation/webhooks-and-callbacks.mdx
@@ -148,6 +148,9 @@ const validUser(email) {
 If you made a document number change, we will perform an asynchronous validation of the person's data. The results of that validation will be sent through webhooks
 
 `UPDATE_DOCUMENT_NUMBER`: After a data validation, you will receive an event with this name where there will be a confirmation message, or an error message because there was a discrepancy in the user's data.
+- `document_number_sucessfully_updated`: The data verification process finished with success and the document number has been updated.
+
+- `document_number_failed_to_update`: There was an error during the verification flow, ie: "Account does not have any personal info", "Account not found",  "There is incompatible personal info between the account and metamap". 
 
 
 

--- a/english/documentation/webhooks-and-callbacks.mdx
+++ b/english/documentation/webhooks-and-callbacks.mdx
@@ -155,9 +155,13 @@ Example of a request:
 
 ```json
 {
-  "eventName": "UPDATE_DOCUMENT_NUMBER",
-  "message": "There is incompatible personal info between the account and metamap",
-  "timeStamp": "2022-10-26T22:36:41.658Z",
-  "signature": "ed40d34ab7a587cf1a16338a16cc7765ae4420936677482bb33f5f738e4f7189" // hash
+"eventName": "document_number_sucessfully_updated", // Or "document_number_failed_to_update" if failed,
+"orderId": "UPDATE_DOCUMENT_NUMBER",
+"timeStamp": "2022-10-26T22:36:41.658Z",
+"data": {
+"email": {{email}},
+"message": {{error or success message}}
+},
+"signature": "ed40d34ab7a587cf1a16338a16cc7765ae4420936677482bb33f5f738e4f7189" // hash
 }
 ```


### PR DESCRIPTION
Change the event fired after updating document number to be more usefull for clients, the new event body will be:

{
"eventName": "document_number_sucessfully_updated", // O "document_number_failed_to_update" si falló,
"orderId": "UPDATE_DOCUMENT_NUMBER",
"timeStamp": "2022-10-26T22:36:41.658Z",
"data": {
"email": {{email}},
"message": {{Mensaje de error}}
},
"signature": "ed40d34ab7a587cf1a16338a16cc7765ae4420936677482bb33f5f738e4f7189" // hash
}