### PR TITLE
Update meeting links in documentation

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -25,7 +25,7 @@
     {
       "name": "Hablemos",
       "version": "Español",
-      "url": "https://meetings.hubspot.com/seba-koywe/team",
+      "url": "https://hs.koywe.com/meetings/cata-aguirre/docs-koywe",
       "icon": "phone"
     },
     {
@@ -37,7 +37,7 @@
     {
       "name": "Let's Talk",
       "version": "English",
-      "url": "https://meetings.hubspot.com/seba-koywe/team",
+      "url": "https://hs.koywe.com/meetings/cata-aguirre/docs-koywe",
       "icon": "phone"
     },
     {


### PR DESCRIPTION
change seba => cata 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated meeting scheduling links for both Spanish ("Hablemos") and English ("Let's Talk") sessions, so users are directed to the new, correct meeting pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->